### PR TITLE
use uiop instead of osicat

### DIFF
--- a/cl-gists.asd
+++ b/cl-gists.asd
@@ -27,7 +27,7 @@
                :dexador
                :babel
                :jonathan
-               :osicat)
+               :uiop)
   :components ((:module "src"
                 :serial t
                 :components

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -2,8 +2,8 @@
 (defpackage cl-gists.util
   (:use :cl
         :annot.doc)
-  (:import-from :osicat
-                :environment-variable)
+  (:import-from :uiop
+                :getenv)
   (:import-from :alexandria
                 :remove-from-plist)
   (:import-from :local-time
@@ -59,7 +59,7 @@
 (defgeneric username (credentials)
   (:method ((credentials t))
     (declare (ignore credentials))
-    (environment-variable *github-username-env-var*)))
+    (getenv *github-username-env-var*)))
 
 @doc
 "Return the password."

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -66,14 +66,14 @@
 (defgeneric password (credentials)
   (:method ((credentials t))
     (declare (ignore credentials))
-    (environment-variable *github-password-env-var*)))
+    (getenv *github-password-env-var*)))
 
 @doc
 "Return the OAuth token."
 (defgeneric oauth-token (credentials)
   (:method ((credentials t))
     (declare (ignore credentials))
-    (environment-variable *github-oauth-token-env-var*)))
+    (getenv *github-oauth-token-env-var*)))
 
 (defun format-timestring-for-api (timestamp)
   (format-timestring nil


### PR DESCRIPTION
It is easier to load it from windows environment.
I know there could be disadvantage to choose uiop over osicat,like setting up dependency for old released version lisp.
anyway...
