### PR TITLE
return response headers

### DIFF
--- a/src/util.lisp
+++ b/src/util.lisp
@@ -83,7 +83,7 @@
                      :timezone +utc-zone+))
 
 (defun request (uri &key method content ignore-statuses (credentials *credentials*))
-  (multiple-value-bind (body status)
+  (multiple-value-bind (body status response-headers)
       (handler-bind ((dex:http-request-failed (lambda (c)
                                                 (declare (ignore c))
                                                 (invoke-restart 'dex:ignore-and-continue))))
@@ -102,10 +102,10 @@
                             body
                             (octets-to-string body :encoding :utf-8))))
       (cond
-        ((and (<= 200 status) (<= status 299))
-         (values string-body status))
+        ((<= 200 status 299)
+         (values string-body status response-headers))
         (t (if (and ignore-statuses (member status ignore-statuses))
-               (values string-body status)
+               (values string-body status response-headers)
                (error "URI: ~a~%Method: ~a~%Content: ~a~%Status: ~a~%Message: ~a~%"
                       uri
                       method


### PR DESCRIPTION
If there are many objects github api should returns, "link" response header would be important to know how to know uri to retrieve remaining objects.

see https://developer.github.com/v3/gists/#list-all-public-gists.

this patch is just modified internal function to return response-headers but it'll never bother other functionalities.
